### PR TITLE
Version 1.3

### DIFF
--- a/Basic_Parameter.h
+++ b/Basic_Parameter.h
@@ -2,9 +2,9 @@
 // change basic set to simulate a harris-current-layer problem
 
 // Grid Number
-const int Grid_Num_x=41;     // VS run, maximum value is 13 
-const int Grid_Num_y=41;
-const int Grid_Num_z=4;     // set Grid_Num_z=4, and make all 
+const int Grid_Num_x=11;     // VS run, maximum value is 13 
+const int Grid_Num_y=9;
+const int Grid_Num_z=13;     // set Grid_Num_z=4, and make all 
 			     // variables independent on y, we can simulate 2D situation
 
 // Controlling and Logical Parameter
@@ -12,10 +12,10 @@ const int Grid_Num_z=4;     // set Grid_Num_z=4, and make all
 const Logic uniform_x=True;
 const Logic uniform_y=True;       // Unifrom mesh or non-uniform mesh
 const Logic uniform_z=True;       // Fortran doesn't use it!
-const Logic period_y=True;        // False;       // Periodic Condition in Y-direction
-const Logic half_x=False;
+const Logic period_y=True; // False;        // False;       // Periodic Condition in Y-direction
+const Logic half_x=True;  //False;
 // const Logic half_y=False;         // Symmetric or antisymmetric simulation
-const Logic half_z=False;
+const Logic half_z=False;  //False;
 
 // Spatial Range
 const double x_min=1.;
@@ -27,15 +27,15 @@ const double z_max=5.;
 
 // Physical Parameter
 const double phy_gamma=1.66667; //5./3. means physics_gamma;
-const double beta_m=0.01;
-const double rho_m_0=1.;            // 1.
-const double rho_s_0=1.;            // 1.
+const double beta_m=0.1;        // 0.01
+const double rho_m_0=7.33;            // 1.
+const double rho_s_0=7.33;            // 1.
 const double width_rho=1.;         // 1.
-const double B_m_0=1.;             // 1.
-const double B_s_0=1;             // 1.
-const double v_0=.0;               // 0.
-const double vyi_0=.0;             // 0.
-const double di=.0;                // 0.  what's its meaning???????? used in current amendation and V_cross_B in flux calculation
+const double B_m_0=13.;             // 1.
+const double B_s_0=11.;             // 1.
+const double v_0=7.;               // 0.
+const double vyi_0=2.30;             // 0.
+const double di=0.3;                // 0.  what's its meaning???????? used in current amendation and V_cross_B in flux calculation
 
 const int Num_Smooth_x=2*Grid_Num_x/3;
 const int Num_Smooth_y=3*Grid_Num_y/4;

--- a/Basic_Parameter.h
+++ b/Basic_Parameter.h
@@ -2,9 +2,9 @@
 // change basic set to simulate a harris-current-layer problem
 
 // Grid Number
-const int Grid_Num_x=11;     // VS run, maximum value is 13 
-const int Grid_Num_y=9;
-const int Grid_Num_z=13;     // set Grid_Num_z=4, and make all 
+const int Grid_Num_x=41;     // VS run, maximum value is 13 
+const int Grid_Num_y=7;
+const int Grid_Num_z=41;     // set Grid_Num_z=4, and make all 
 			     // variables independent on y, we can simulate 2D situation
 
 // Controlling and Logical Parameter
@@ -13,9 +13,9 @@ const Logic uniform_x=True;
 const Logic uniform_y=True;       // Unifrom mesh or non-uniform mesh
 const Logic uniform_z=True;       // Fortran doesn't use it!
 const Logic period_y=True; // False;        // False;       // Periodic Condition in Y-direction
-const Logic half_x=True;  //False;
+const Logic half_x=False;
 // const Logic half_y=False;         // Symmetric or antisymmetric simulation
-const Logic half_z=False;  //False;
+const Logic half_z=False;
 
 // Spatial Range
 const double x_min=1.;
@@ -27,15 +27,15 @@ const double z_max=5.;
 
 // Physical Parameter
 const double phy_gamma=1.66667; //5./3. means physics_gamma;
-const double beta_m=0.1;        // 0.01
-const double rho_m_0=7.33;            // 1.
-const double rho_s_0=7.33;            // 1.
+const double beta_m=0.01;        // 0.01
+const double rho_m_0=1.;            // 1.
+const double rho_s_0=1.;            // 1.
 const double width_rho=1.;         // 1.
-const double B_m_0=13.;             // 1.
-const double B_s_0=11.;             // 1.
-const double v_0=7.;               // 0.
-const double vyi_0=2.30;             // 0.
-const double di=0.3;                // 0.  what's its meaning???????? used in current amendation and V_cross_B in flux calculation
+const double B_m_0=1.;             // 1.
+const double B_s_0=1.;             // 1.
+const double v_0=0.;               // 0.
+const double vyi_0=0.;             // 0.
+const double di=0.;                // 0.  what's its meaning???????? used in current amendation and V_cross_B in flux calculation
 
 const int Num_Smooth_x=2*Grid_Num_x/3;
 const int Num_Smooth_y=3*Grid_Num_y/4;

--- a/Important_Procedure.cpp
+++ b/Important_Procedure.cpp
@@ -149,7 +149,7 @@ void initialize(VARIABLE *pointer, BASIC_VARIABLE &pressure_obj)
 				pointer[4].value[i][j][k]=Bx;
 				pointer[5].value[i][j][k]=By;
 				pointer[6].value[i][j][k]=Bz;				
-				rhoVx=3.27;
+				rhoVx=0.;
 				rhoVy=0.5*v0*By*(1-tanh(x/width_rho))*rho/bs;
 				rhoVz=0.5*v0*Bz*(1-tanh(x/width_rho))*rho/bs;
 				pointer[1].value[i][j][k]=rhoVx;
@@ -170,7 +170,7 @@ void initialize(VARIABLE *pointer, BASIC_VARIABLE &pressure_obj)
 				sub_var[4][i][j][k]=Bx;
 				sub_var[5][i][j][k]=By;
 				sub_var[6][i][j][k]=Bz;
-				rhoVx=3.27;
+				rhoVx=0.;
 				rhoVy=0.5*v0*By*(1-tanh((x+dx/2.)/width_rho))*rho/bs;
 				rhoVz=0.5*v0*Bz*(1-tanh((x+dx/2.)/width_rho))*rho/bs;
 				sub_var[1][i][j][k]=rhoVx;

--- a/Important_Procedure.cpp
+++ b/Important_Procedure.cpp
@@ -23,7 +23,7 @@ void set_mesh()
 	Y[0]=y_min;
 	Z[0]=z_min;
 	nx=Grid_Num_x-1;
-	ny=Grid_Num_x-1;
+	ny=Grid_Num_y-1;
 	nz=Grid_Num_z-1;
 	ofstream out("grid.dat");
 	ofstream out_2D("grid_2D.dat");
@@ -149,7 +149,7 @@ void initialize(VARIABLE *pointer, BASIC_VARIABLE &pressure_obj)
 				pointer[4].value[i][j][k]=Bx;
 				pointer[5].value[i][j][k]=By;
 				pointer[6].value[i][j][k]=Bz;				
-				rhoVx=0;
+				rhoVx=3.27;
 				rhoVy=0.5*v0*By*(1-tanh(x/width_rho))*rho/bs;
 				rhoVz=0.5*v0*Bz*(1-tanh(x/width_rho))*rho/bs;
 				pointer[1].value[i][j][k]=rhoVx;
@@ -170,7 +170,7 @@ void initialize(VARIABLE *pointer, BASIC_VARIABLE &pressure_obj)
 				sub_var[4][i][j][k]=Bx;
 				sub_var[5][i][j][k]=By;
 				sub_var[6][i][j][k]=Bz;
-				rhoVx=0;
+				rhoVx=3.27;
 				rhoVy=0.5*v0*By*(1-tanh((x+dx/2.)/width_rho))*rho/bs;
 				rhoVz=0.5*v0*Bz*(1-tanh((x+dx/2.)/width_rho))*rho/bs;
 				sub_var[1][i][j][k]=rhoVx;
@@ -327,14 +327,14 @@ void cal_current(VARIABLE *current, VARIABLE *pointer, Type T)
 		{
 			for (i=0;i<Grid_Num_x;i++)
 			{
-				for (j=0;j<Grid_Num_z;j++)
+				for (j=0;j<Grid_Num_y;j++)
 				{
 					current[0].value[i][j][0]=current[0].value[i][j][1];
-					current[0].value[i][j][Grid_Num_z-1]=current[0].value[i][j][Grid_Num_y-3];
+					current[0].value[i][j][Grid_Num_z-1]=current[0].value[i][j][Grid_Num_z-3];
 					current[1].value[i][j][0]=current[1].value[i][j][1];
-					current[1].value[i][j][Grid_Num_z-1]=current[2].value[i][j][Grid_Num_y-3];
-					current[2].value[i][j][0]=current[n].value[i][j][1];
-					current[2].value[i][j][Grid_Num_z-1]=-current[2].value[i][j][Grid_Num_y-3];
+					current[1].value[i][j][Grid_Num_z-1]=current[1].value[i][j][Grid_Num_z-3];
+					current[2].value[i][j][0]=current[2].value[i][j][1];
+					current[2].value[i][j][Grid_Num_z-1]=-current[2].value[i][j][Grid_Num_z-3];
 				}
 			}
 		}
@@ -344,10 +344,10 @@ void cal_current(VARIABLE *current, VARIABLE *pointer, Type T)
 			{
 				for (i=0;i<Grid_Num_x;i++)
 				{
-					for (j=0;j<Grid_Num_z;j++)
+					for (j=0;j<Grid_Num_y;j++)
 					{
 						current[n].value[i][j][0]=current[n].value[i][j][1];
-						current[n].value[i][j][Grid_Num_z-1]=current[n].value[i][j][Grid_Num_y-2];
+						current[n].value[i][j][Grid_Num_z-1]=current[n].value[i][j][Grid_Num_z-2];
 					}
 				}
 			}
@@ -423,14 +423,14 @@ void cal_current(VARIABLE *current, VARIABLE *pointer, Type T)
 		{
 			for (i=0;i<Grid_Num_x-T;i++)
 			{
-				for (j=0;j<Grid_Num_z-T;j++)
+				for (j=0;j<Grid_Num_y-T;j++)
 				{
 					current[0].value[i][j][0]=current[0].value[i][j][1];
-					current[0].value[i][j][Grid_Num_z-1-T]=current[0].value[i][j][Grid_Num_y-2-T];
+					current[0].value[i][j][Grid_Num_z-1-T]=current[0].value[i][j][Grid_Num_z-2-T];
 					current[1].value[i][j][0]=current[1].value[i][j][1];
-					current[1].value[i][j][Grid_Num_z-1-T]=current[1].value[i][j][Grid_Num_y-2-T];
+					current[1].value[i][j][Grid_Num_z-1-T]=current[1].value[i][j][Grid_Num_z-2-T];
 					current[2].value[i][j][0]=current[2].value[i][j][1];
-					current[2].value[i][j][Grid_Num_z-1-T]=-current[2].value[i][j][Grid_Num_y-2-T];
+					current[2].value[i][j][Grid_Num_z-1-T]=-current[2].value[i][j][Grid_Num_z-2-T];
 				}
 			}
 		}
@@ -440,10 +440,10 @@ void cal_current(VARIABLE *current, VARIABLE *pointer, Type T)
 			{
 				for (i=0;i<Grid_Num_x-T;i++)
 				{
-					for (j=0;j<Grid_Num_z-T;j++)
+					for (j=0;j<Grid_Num_y-T;j++)
 					{
 						current[n].value[i][j][0]=current[n].value[i][j][1];
-						current[n].value[i][j][Grid_Num_z-1-T]=current[n].value[i][j][Grid_Num_y-2-T];
+						current[n].value[i][j][Grid_Num_z-1-T]=current[n].value[i][j][Grid_Num_z-2-T];
 					}
 				}
 			}

--- a/Variables_Definition.cpp
+++ b/Variables_Definition.cpp
@@ -67,8 +67,8 @@ void VARIABLE::boundary_set(Symmetry_Type sign_x, Symmetry_Type sign_z)
 					{
 						for(k=1;k<Grid_Num_z-1;k++)
 						{
-							value[i][0][k]=value[i][Grid_Num_z-2][k];
-							value[i][Grid_Num_z-1][k]=value[i][1][k];
+							value[i][0][k]=value[i][Grid_Num_y-2][k];
+							value[i][Grid_Num_y-1][k]=value[i][1][k];
 						}
 					}
 				}
@@ -79,7 +79,7 @@ void VARIABLE::boundary_set(Symmetry_Type sign_x, Symmetry_Type sign_z)
 						for(k=1;k<Grid_Num_z-1;k++)
 						{
 							value[i][0][k]=value[i][1][k];
-							value[i][Grid_Num_z-1][k]=value[i][Grid_Num_z-2][k];
+							value[i][Grid_Num_y-1][k]=value[i][Grid_Num_y-2][k];
 						}
 					}
 				}


### PR DESCRIPTION
1. Version-1.3 can give exactly the same results with same initial value comparing with fortran-code. 
2. Remark: 
- In exclude_source_half_update() located in 'General_Procedure.cpp',  which is a sub_function of step_on()  function locate d in 'Importran_Procedure.cpp', its's statement: `update_var[].value[][][]=var_x_plushalfdx[][]+Temp_var[][][]+dtflux_x+dtflux_y+dtflux_z;` give rise to little worry about the real intention of using `var_x_plushalfdx[]+Temp_var[][][]`, because that in first time the statement is implemented, `Temp_var[][][]` is set to zero.  Maybe later I could add another statement, like that `Temp_var[][][]` is linked to `update_var[][][]-var_x[][]`.

